### PR TITLE
docs: add persistent storage pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -87,11 +87,17 @@ export default defineConfig({
         label: "WebSocket Client Class",
         link: "/api/websocket-client-class"
       }, {
-        label: "MQTT Client Class",
-        link: "/api/mqtt-client-class"
-      }, {
-        label: "Host Provider",
-        link: "/api/host-provider"
+         label: "MQTT Client Class",
+         link: "/api/mqtt-client-class"
+       }, {
+         label: "Persistent Storage",
+         autogenerate: {
+           directory: "/api/storage"
+         },
+         collapsed: true
+       }, {
+         label: "Host Provider",
+         link: "/api/host-provider"
       }, {
         label: "Provenance Sensor Class",
         link: "/api/provenance-sensor-class"

--- a/src/content/docs/api/index.md
+++ b/src/content/docs/api/index.md
@@ -3,7 +3,37 @@ title: API Overview
 description: Overview of the ECMA-419 embedded systems API.
 ---
 
-The ECMA-419 specification defines a suite of APIs for JavaScript on embedded systems. These APIs are organized into several patterns and classes.
+# API Reference
+
+## Overview
+
+The first edition of the ECMA Standard was adopted by the ECMA General Assembly of June 2021. It was built around the IO Class Pattern which provides consistent, efficient, extensible access to the IO capabilities of embedded systems. Driver-style classes for IO extenders, sensors, and displays build on the IO foundation.
+
+The second edition extends IO with asynchronous capabilities used by I²C and the system management bus. It introduces new sensor classes, including many gas sensors; classes to manage and monitor network interfaces; client support for common network protocols including HTTP, MQTT, NTP, DNS, WebSocket, and TLS; server support for the HTTP and WebSocket protocols; and a real-time clock peripheral class.
+
+## Scope
+
+The Standard defines application programming interfaces (APIs) for ECMAScript modules that support programs executing on embedded systems.
+
+The Standard defines APIs for capabilities found in common across embedded systems. Implementations for embedded systems that include additional capabilities are encouraged to provide ECMAScript APIs for those using the many extensibility options provided by the Standard.
+
+The Standard does not make any changes to the ECMAScript language as defined by ECMAScript Language Specification (ECMA-262).
+
+## Class Pattern
+
+A Class Pattern, as used in the Standard, is a combination of requirements and guidelines for a class. For example, the IO Class Pattern defines behaviours for all IO classes.
+
+## Module Specifiers
+
+The Standard defines classes which are accessed through modules. Because many embedded systems lack a file system, using file paths to access modules is impractical. Instead, modules are accessed using bare module specifiers. While such specifiers are currently forbidden in a web browser, they are permitted in other environments.
+
+A namespace prefix is used to minimise the chance of name collisions with other bare module specifiers. This Standard uses the namespace prefix **`embedded:`**.
+
+```
+import Digital from "embedded:io/digital";
+```
+
+The use of module namespaces in this Standard is intended to be compatible with the [Built In Modules Proposal](https://github.com/tc39/proposal-built-in-modules#namespace).
 
 ## Patterns
 

--- a/src/content/docs/api/index.md
+++ b/src/content/docs/api/index.md
@@ -23,7 +23,7 @@ The ECMA-419 specification defines a suite of APIs for JavaScript on embedded sy
 - [**HTTP Server**](/api/http-server-class): Web responses.
 - [**WebSocket Client**](/api/websocket-client-class): Real-time web communication.
 - [**MQTT Client**](/api/mqtt-client-class): Message queuing telemetry transport.
-- [**Persistent Storage**](/api/storage/files): Files, key-value pairs, and flash memory.
+- [**Persistent Storage**](/api/storage/): Files, key-value pairs, and flash memory.
 
 ## Host Provider
 

--- a/src/content/docs/api/storage/index.md
+++ b/src/content/docs/api/storage/index.md
@@ -1,0 +1,93 @@
+---
+title: Persistent Storage
+description: Overview of persistent storage modules for files, flash memory, and key-value pairs.
+---
+
+The Persistent Storage APIs provide mechanisms for reliable data storage on embedded systems. ECMA-419 defines four complementary storage modules, each optimized for different use cases and access patterns.
+
+## Storage Types
+
+### Files
+The **Files** module provides a hierarchical file system interface for storing, organizing, and retrieving data in a directory structure. It supports:
+- Creating and navigating directories
+- Reading and writing files with various access modes
+- Moving, copying, and deleting files and directories
+- Symbolic links for file system abstraction
+- Synchronous or asynchronous operations
+
+Use the Files module when you need a traditional file system interface with structured organization, similar to operating system file systems.
+
+**Module**: `embedded:storage/files`  
+**Documentation**: [Files](/api/storage/files)
+
+### Flash
+The **Flash** module provides low-level access to flash memory partitions for advanced use cases requiring direct hardware control. It supports:
+- Opening flash partitions by name
+- Reading and writing raw data at byte offsets
+- Erasing memory blocks (sectors)
+- Querying partition size and block information
+- Multiple data format support
+
+Use the Flash module when you need direct control over flash memory partitions, such as for boot loaders, raw data storage, or performance-critical applications.
+
+**Module**: `embedded:storage/flash`  
+**Documentation**: [Flash](/api/storage/flash)
+
+### Key-Value
+The **Key-Value** module provides simple key-value pair storage organized within named domains. It supports:
+- Reading and writing values by key
+- Deleting key-value pairs
+- Domain organization for logical separation
+- Multiple data format support
+- Transactional operations
+
+Use the Key-Value module when you need simple, fast access to configuration data, application settings, or small cached values without file system overhead.
+
+**Module**: `embedded:storage/key-value`  
+**Documentation**: [Key-Value](/api/storage/key-value)
+
+### Update
+The **Update** module provides firmware update functionality, enabling in-place firmware upgrades for flash partitions. It supports:
+- Writing update data in append or random-access modes
+- Progress tracking and cancellation
+- Atomic activation of updates
+- Automatic rollback on failure
+
+Use the Update module to implement over-the-air (OTA) firmware updates, allowing devices to update themselves without external tools.
+
+**Module**: `embedded:update`  
+**Documentation**: [Update](/api/storage/update)
+
+## Choosing a Storage Type
+
+| Use Case | Recommended Module | Reason |
+|----------|-------------------|--------|
+| Application files, documents | **Files** | Natural hierarchical organization |
+| Configuration settings | **Key-Value** | Fast, simple access to small data |
+| Raw data, boot code | **Flash** | Direct hardware control |
+| Firmware updates | **Update** | Safe, atomic firmware replacement |
+| Multi-file projects | **Files** | Directory structure and navigation |
+| Cached values | **Key-Value** | Low overhead, quick lookup |
+| Legacy binary formats | **Flash** | Arbitrary byte-level access |
+
+## Getting Started
+
+Each storage module is accessed through the `device.storage` global object:
+
+```js
+import files from "embedded:storage/files";
+import flash from "embedded:storage/flash";
+import keyValue from "embedded:storage/key-value";
+import update from "embedded:update";
+
+// Access persistent storage modules
+const rootDir = files;
+const partition = await flash.open({ path: "app" });
+const config = await keyValue.open({ path: "settings" });
+```
+
+Refer to each module's documentation page for detailed API reference, parameters, and code examples.
+
+## Specifications
+
+[Persistent Storage (Section 26)](https://419.ecma-international.org/#-26-persistent-storage)


### PR DESCRIPTION
The API Overview page has also been expanded to include quick links to the various class patterns and providers. 